### PR TITLE
Convert attribute values to string to prevent error when stripping white space

### DIFF
--- a/src/data_layer/read_attendees.py
+++ b/src/data_layer/read_attendees.py
@@ -32,7 +32,7 @@ def read_attendees(parameters: Parameters) -> list[Attendee]:
     for row in attendees_df.itertuples(index=False):
         # noinspection PyProtectedMember
         row_as_dict = row._asdict()
-        attributes_used = {k.strip(): v.strip()
+        attributes_used = {k.strip(): str(v).strip()
                            for k, v in row_as_dict.items()
                            if k.strip() in parameters.attribute_field_names}
         attendee = Attendee(row_as_dict[parameters.id_field_name],


### PR DESCRIPTION
When attributes contained numerical datatypes, an AttributeError would be raised due to the use of the strip method. Code now converts all attributes to string type before applying strip to prevent this from occurring. 